### PR TITLE
fix: sidebar hides options when mouse enters

### DIFF
--- a/src/containers/editor/sidenav/index.tsx
+++ b/src/containers/editor/sidenav/index.tsx
@@ -23,7 +23,7 @@ import Button from "./Button";
 import ExportPopover from "./ExportPopover";
 import ImportPopover from "./ImportPopover";
 import LinkButton from "./LinkButton";
-import PopoverBtn from "./PopoverButton";
+import PopoverBtn, { popoverBtnClass } from "./PopoverButton";
 import SharePopover from "./SharePopover";
 import StatisticsPopover from "./StatisticsPopover";
 import Toggle from "./Toggle";
@@ -45,7 +45,12 @@ export default function SideNav() {
   return (
     <div
       className="flex flex-col h-full w-8"
-      onMouseEnter={() => setSideNavExpanded(true)}
+      onMouseEnter={(event) => {
+        if ((event.target as HTMLElement).closest(`.${popoverBtnClass}`)) {
+          return;
+        }
+        setSideNavExpanded(true);
+      }}
       onMouseLeave={() => setSideNavExpanded(false)}
     >
       <nav

--- a/src/containers/editor/sidenav/index.tsx
+++ b/src/containers/editor/sidenav/index.tsx
@@ -23,7 +23,7 @@ import Button from "./Button";
 import ExportPopover from "./ExportPopover";
 import ImportPopover from "./ImportPopover";
 import LinkButton from "./LinkButton";
-import PopoverBtn, { popoverBtnClass } from "./PopoverButton";
+import PopoverBtn from "./PopoverButton";
 import SharePopover from "./SharePopover";
 import StatisticsPopover from "./StatisticsPopover";
 import Toggle from "./Toggle";
@@ -45,16 +45,11 @@ export default function SideNav() {
   return (
     <div
       className="flex flex-col h-full w-8"
-      onMouseEnter={(event) => {
-        if ((event.target as HTMLElement).closest(`.${popoverBtnClass}`)) {
-          return;
-        }
-        setSideNavExpanded(true);
-      }}
+      onMouseEnter={() => setSideNavExpanded(true)}
       onMouseLeave={() => setSideNavExpanded(false)}
     >
       <nav
-        className="group z-50 h-full py-1.5 w-8 data-[expanded=true]:w-32 box-content border-r border-default shadow-xl transition-width duration-200 hide-scrollbar flex flex-col justify-between bg-background"
+        className="group z-50 h-full py-1.5 w-8 data-[expanded=true]:w-32 box-content border-r border-default shadow-xl transition-width duration-200 hide-scrollbar flex flex-col justify-between bg-background overflow-hidden"
         data-expanded={sideNavExpanded}
       >
         <ul className="relative flex flex-col justify-start px-1 gap-y-1">


### PR DESCRIPTION
When the graph is fully expanded, options located at the bottom left of the screen are obstructed by the sidebar, preventing users from accessing them.

**Steps to Reproduce:**

1. Switch to graph mode.
2. Fully expand the graph.
3. Attempt to click an option in the bottom left corner.

**Expected Behavior:**

The user should be able to click the options without obstruction.

**Actual Behavior:**

The sidebar opens, blocking access to the options, making them unclickable.

**Screenshot:**

![example](https://github.com/user-attachments/assets/85d715cb-861b-433f-ab26-5a5ae7c141e6)