### PR TITLE
fix: set w-fit to container in toolbar

### DIFF
--- a/src/containers/editor/graph/Toolbar.tsx
+++ b/src/containers/editor/graph/Toolbar.tsx
@@ -62,11 +62,10 @@ const Toolbar = memo(({ id }: ToolbarProps) => {
   };
 
   // TODO: hide fold button when there is no edges
-  // TODO: fix w-fit doesn't work
   return (
     <NodeToolbar
       isVisible={true}
-      className="flex items-center justify-center w-[96px] h-fit bg-input"
+      className="flex items-center justify-center w-fit h-fit bg-input"
       position={Position.Top}
       align="start"
       offset={0}
@@ -122,7 +121,7 @@ const ToolbarButton = memo(({ title, onClick, children }: ToolbarButtonProps) =>
   return (
     <Button
       variant="icon"
-      className="h-5 w-5 p-1"
+      className="h-6 w-6 p-1"
       title={title}
       onClick={(ev) => {
         ev.preventDefault();


### PR DESCRIPTION
This update implements the following TODOs in the Toolbar component:

~~Hide the fold button when no edges are present, ensuring the button is not shown unnecessarily in cases where it's not needed.~~
- Fix the issue with w-fit, which was not behaving as expected, making necessary adjustments to ensure proper layout functionality.

**Screenshot**:

<img width="1507" alt="example2" src="https://github.com/user-attachments/assets/13ea38f2-55a4-4ad5-b695-dfd4435289d8">

