### PR TITLE
enh: implement graph in treeStore and use in Toolbar

### DIFF
--- a/src/containers/editor/graph/Toolbar.tsx
+++ b/src/containers/editor/graph/Toolbar.tsx
@@ -1,10 +1,11 @@
 import { memo, ReactNode, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { type EdgeWithData, type NodeWithData } from "@/lib/graph/layout";
+import { NodeWithData, EdgeWithData } from "@/lib/graph/layout";
 import { join as idJoin, splitParentPointer, toPath } from "@/lib/idgen";
 import { useEditor } from "@/stores/editorStore";
 import { useStatusStore } from "@/stores/statusStore";
-import { NodeToolbar, Position, useReactFlow } from "@xyflow/react";
+import { useTreeStore } from "@/stores/treeStore";
+import { NodeToolbar, Position } from "@xyflow/react";
 import { ArrowLeft, CopyMinus, CopyPlus, Focus, SquareMinus, SquarePlus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useHandleClick } from "./useHandleClick";
@@ -21,11 +22,19 @@ const Toolbar = memo(({ id }: ToolbarProps) => {
 
   const t = useTranslations();
   const editor = useEditor();
-  // TODO: fix by use full nodes and edges
-  const { getNodes, getEdges, setNodes, setEdges } = useReactFlow<NodeWithData, EdgeWithData>();
-  const nodes = getNodes();
-  const edges = getEdges();
-  const args = { nodes, edges, setNodes, setEdges };
+
+  const {
+    graph: { nodes, edges },
+    setGraph,
+  } = useTreeStore();
+  const setNodes = (newNodes: NodeWithData[]) => setGraph({ edges, nodes: newNodes });
+  const setEdges = (newEdges: EdgeWithData[]) => setGraph({ nodes, edges: newEdges });
+  const args = {
+    nodes,
+    edges,
+    setNodes,
+    setEdges,
+  };
 
   const { callNodeClick } = useNodeClick(args);
   const { callHandleClick } = useHandleClick(args);

--- a/src/stores/treeStore.ts
+++ b/src/stores/treeStore.ts
@@ -1,4 +1,5 @@
 import { type Kind } from "@/lib/editor/editor";
+import { Graph } from "@/lib/graph/layout";
 import { Tree } from "@/lib/parser";
 import { type KeyWithType } from "@/lib/table";
 import { type FunctionKeys } from "@/lib/utils";
@@ -26,9 +27,11 @@ interface TooltipContent {
 export interface TreeState {
   main: Tree;
   secondary: Tree;
+  graph: Graph;
   tooltipContent?: TooltipContent;
 
   setTree: (tree: Tree, kind: Kind) => void;
+  setGraph: (graph: Graph) => void;
   setTooltip: (content: TooltipContent) => void;
   hideTooltip: () => void;
 }
@@ -36,6 +39,7 @@ export interface TreeState {
 const initialStates: Omit<TreeState, FunctionKeys<TreeState>> = {
   main: new Tree(),
   secondary: new Tree(),
+  graph: { nodes: [], edges: [] },
 };
 
 export const useTreeStore = create<TreeState>()((set, get) => ({
@@ -51,6 +55,10 @@ export const useTreeStore = create<TreeState>()((set, get) => ({
 
   hideTooltip() {
     set({ tooltipContent: initialStates.tooltipContent });
+  },
+
+  setGraph(graph: Graph) {
+    set({ graph: graph });
   },
 }));
 


### PR DESCRIPTION
This enhancement introduces a graph data structure, which consists of nodes and edges, to the TreeStore in order to handle the same data used in React Flow.

**Changes:**

- Implemented a graph object in the TreeStore containing nodes and edges.
- Added a useEffect hook in useNodesAndEdges to monitor and sync any changes made to the graph's nodes and edges.

**Reference:**
https://github.com/loggerhead/json4u/pull/44#discussion_r1791628661