### PR TITLE
feat: change transparency when children nodes are collapsed

### DIFF
--- a/src/containers/editor/graph/Handle.tsx
+++ b/src/containers/editor/graph/Handle.tsx
@@ -15,10 +15,12 @@ TargetHandle.displayName = "TargetHandle";
 interface SourceHandleProps {
   id: string;
   indexInParent: number;
+  isChildrenHidden?: boolean;
 }
 
-export const SourceHandle = memo(({ id, indexInParent }: SourceHandleProps) => {
+export const SourceHandle = memo(({ id, indexInParent, isChildrenHidden }: SourceHandleProps) => {
   const top = indexInParent !== undefined ? computeSourceHandleOffset(indexInParent) : undefined;
-  return <Handle type="source" isConnectable id={id} position={Position.Right} style={{ top }} />;
+  const opacity = isChildrenHidden ? 0.5 : undefined;
+  return <Handle type="source" isConnectable id={id} position={Position.Right} style={{ top, opacity }} />;
 });
 SourceHandle.displayName = "SourceHandle";

--- a/src/containers/editor/graph/Node.tsx
+++ b/src/containers/editor/graph/Node.tsx
@@ -58,6 +58,7 @@ export const ObjectNode = memo(({ id, data }: NodeProps<NodeWithData>) => {
                   valueClassName={className}
                   valueText={text}
                   hasChildren={hasChildren(child)}
+                  isChildrenHidden={getNode(child.id)?.hidden ?? false}
                   width={width}
                 />
               );
@@ -80,9 +81,10 @@ interface KvProps {
   valueText: string;
   hasChildren: boolean;
   width: number; // used to avoid width jump when viewport changes
+  isChildrenHidden: boolean;
 }
 
-const KV = memo(({ index, property, valueClassName, valueText, hasChildren, width }: KvProps) => {
+const KV = memo(({ index, property, valueClassName, valueText, hasChildren, width, isChildrenHidden }: KvProps) => {
   const keyText = genKeyText(property);
   const keyClass = typeof property === "number" ? "text-hl-index" : keyText ? "text-hl-key" : "text-hl-empty";
 
@@ -94,7 +96,7 @@ const KV = memo(({ index, property, valueClassName, valueText, hasChildren, widt
       <div contentEditable="true" suppressContentEditableWarning className={cn("graph-v", valueClassName)}>
         {valueText}
       </div>
-      {hasChildren && <SourceHandle id={keyText} indexInParent={index} />}
+      {hasChildren && <SourceHandle id={keyText} indexInParent={index} isChildrenHidden={isChildrenHidden} />}
     </div>
   );
 });

--- a/src/containers/editor/graph/Toolbar.tsx
+++ b/src/containers/editor/graph/Toolbar.tsx
@@ -14,7 +14,6 @@ interface ToolbarProps {
   id: string;
 }
 
-// TODO: change to a color with higher transparency for the source handle when node is collapsed.
 const Toolbar = memo(({ id }: ToolbarProps) => {
   const t = useTranslations();
   const editor = useEditor();


### PR DESCRIPTION
This feature introduces a visual enhancement where a node becomes semi-transparent when its children nodes are collapsed. Tailwind's opacity-50 class has been applied to the node component in Node.tsx to achieve this effect, providing a clearer visual distinction between collapsed and visible nodes.

**Changes:**

- Applied Tailwind’s opacity-50 class to a node when its children are collapsed.