### PR TITLE
feat: set content editable to overflowing text in table mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -280,7 +280,7 @@ body {
       display: inline-block;
       max-width: var(--max-key-length);
       white-space: nowrap;
-      overflow-x: auto;
+      overflow-x: hidden;
     }
 
     :not(:first-child) {
@@ -314,7 +314,7 @@ body {
     display: inline-block;
     max-width: var(--max-value-length);
     white-space: nowrap;
-    overflow-x: auto;
+    overflow-x: hidden;
   }
 }
 

--- a/src/lib/table/index.ts
+++ b/src/lib/table/index.ts
@@ -36,9 +36,19 @@ function genDom(tree: Tree, node: Node, addExpander?: boolean): H {
   if (node.type === "string") {
     return h("span", node.value || '""')
       .class("tbl-val", node.value ? "text-hl-string" : "text-hl-empty")
+      .addAttributes([
+        ["contentEditable", "true"],
+        ["suppressContentEditableWarning", ""],
+      ])
       .id(id);
   } else {
-    return h("span", getRawValue(node)!).class("tbl-val", `text-hl-${node.type}`).id(id);
+    return h("span", getRawValue(node)!)
+      .class("tbl-val", `text-hl-${node.type}`)
+      .addAttributes([
+        ["contentEditable", "true"],
+        ["suppressContentEditableWarning", ""],
+      ])
+      .id(id);
   }
 }
 
@@ -111,7 +121,15 @@ function genTableHeader(tree: Tree, node: Node, key: string, expanderId?: string
     .join("\n");
   const keyDom = h("span", key || '""').class(key ? "text-hl-key" : "text-hl-empty");
 
-  return h("th", h("div", keyDom, genExpander(expanderId)).class("tbl-key")).title(title);
+  return h(
+    "th",
+    h("div", keyDom, genExpander(expanderId))
+      .addAttributes([
+        ["contentEditable", "true"],
+        ["suppressContentEditableWarning", ""],
+      ])
+      .class("tbl-key"),
+  ).title(title);
 }
 
 function genExpander(expanderId?: string) {

--- a/src/lib/table/tag.ts
+++ b/src/lib/table/tag.ts
@@ -9,6 +9,7 @@ export class H {
   attrId?: string;
   attrClass: string[];
   attrTitle?: string;
+  attributes?: Array<[key: string, value: string]>;
   children: (H | string)[];
 
   constructor(tag: string = "", ...children: (H | string)[]) {
@@ -42,6 +43,11 @@ export class H {
     return this;
   }
 
+  addAttributes(attributes: Array<[key: string, value: string]>) {
+    this.attributes = attributes;
+    return this;
+  }
+
   toString(): string {
     const childrenStr = this.children
       .map((child) => (typeof child === "string" ? escape(child) : child.toString()))
@@ -54,6 +60,7 @@ export class H {
       this.attrId && attrs.push(`id="${this.attrId}"`);
       this.attrClass.length && attrs.push(`class="${this.attrClass.join(" ")}"`);
       this.attrTitle && attrs.push(`title="${this.attrTitle}"`);
+      this.attributes?.forEach(([key, value]) => attrs.push(value ? `${key}="${value}"` : key));
       return `<${this.tag} ${attrs.join(" ")}>${childrenStr}</${this.tag}>`;
     }
   }


### PR DESCRIPTION
This feature update sets specific table cells in table mode to be contentEditable="true", allowing users to edit text directly. Additionally, it ensures that overflowing text within these cells is visible and scrollable, keeping the view consistent with graph mode. The suppressContentEditableWarning flag is also activated to prevent unnecessary warnings in React.

**Changes**
- Applied contentEditable="true" to relevant table cells in table mode, enabling inline text editing.
- Enabled suppressContentEditableWarning in React to prevent unwanted console warnings.
- Updated the CSS to set overflow-x: hidden, hiding the horizontal scrollbar when showing the overflowing text.
