### PR TITLE
feat: implement popover to show text in graph mode

### DIFF
--- a/e2e/tests/graph.spec.ts
+++ b/e2e/tests/graph.spec.ts
@@ -35,4 +35,26 @@ test.describe("Virtual graph", () => {
     await move(page, 2000, 2000);
     await expect(getGraphNode(page, "$")).toBeHidden();
   });
+
+  test("it should render popover when a key node is hovered by mouse.", async ({ page }) => {
+    await getEditor(page, { goto: true });
+
+    const keyNode = page.locator(".graph-k");
+    const box = await keyNode.first().boundingBox();
+
+    expect(box).toBeTruthy();
+    await page.mouse.move(box!.x, box!.y);
+    await expect(page.getByTestId("popover-key").first()).toBeVisible();
+  });
+
+  test("it should render popover when a value node is hovered by mouse.", async ({ page }) => {
+    await getEditor(page, { goto: true });
+
+    const valueNode = page.locator(".graph-v");
+    const box = await valueNode.first().boundingBox();
+
+    expect(box).toBeTruthy();
+    await page.mouse.move(box!.x, box!.y);
+    await expect(page.getByTestId("popover-value").first()).toBeVisible();
+  });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -253,6 +253,7 @@ body {
   max-width: var(--max-key-length);
   white-space: nowrap;
   overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 
 .graph-v {
@@ -260,6 +261,23 @@ body {
   margin-left: auto;
   white-space: nowrap;
   overflow-x: hidden;
+  text-overflow: ellipsis;
+}
+
+.popover-container {
+  display: flex;
+  height: auto;
+  max-height: 250px;
+  overflow: hidden;
+
+  .popover-item {
+    width: max-content;
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+    word-wrap: break-word;
+    font-size: 12px;
+    padding: 10px 20px;
+  }
 }
 
 .tbl {

--- a/src/containers/editor/graph/Node.tsx
+++ b/src/containers/editor/graph/Node.tsx
@@ -5,6 +5,7 @@ import { rootMarker } from "@/lib/idgen/pointer";
 import { getChildrenKeys, hasChildren } from "@/lib/parser/node";
 import { cn } from "@/lib/utils";
 import { useTree } from "@/stores/treeStore";
+import * as Tooltip from "@radix-ui/react-tooltip";
 import { Handle, Position, useReactFlow, type NodeProps } from "@xyflow/react";
 import { filter } from "lodash-es";
 import { SourceHandle, TargetHandle } from "./Handle";
@@ -87,12 +88,28 @@ const KV = memo(({ id, index, property, valueClassName, valueText, hasChildren, 
 
   return (
     <div className="graph-kv" style={{ width }} data-tree-id={id}>
-      <div contentEditable="true" suppressContentEditableWarning className={cn("graph-k", keyClass)}>
-        {keyText}
-      </div>
-      <div contentEditable="true" suppressContentEditableWarning className={cn("graph-v", valueClassName)}>
-        {valueText}
-      </div>
+      <Popover
+        content={
+          <div className="popover-container" data-testid="popover-key">
+            <div className={cn("popover-item", keyClass)} style={{ maxWidth: width }}>
+              {keyText}
+            </div>
+          </div>
+        }
+      >
+        <div className={cn("graph-k", keyClass)}>{keyText}</div>
+      </Popover>
+      <Popover
+        content={
+          <div className="popover-container" data-testid="popover-value">
+            <div className={cn("popover-item", valueClassName)} style={{ maxWidth: width }}>
+              {valueText}
+            </div>
+          </div>
+        }
+      >
+        <div className={cn("graph-v", valueClassName)}>{valueText}</div>
+      </Popover>
       {hasChildren && <SourceHandle id={keyText} indexInParent={index} isChildrenHidden={isChildrenHidden} />}
     </div>
   );
@@ -128,3 +145,16 @@ export const VirtualTargetNode = memo(() => {
   );
 });
 VirtualTargetNode.displayName = "VirtualTargetNode";
+
+function Popover({ children, content }: React.PropsWithChildren<{ content: JSX.Element }>): JSX.Element {
+  return (
+    <Tooltip.Provider>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content side="top">{content}</Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+}


### PR DESCRIPTION
This replaces the contentEditable functionality with a customized popover in the graph mode

**Changes:**
- ~~Replaced contentEditable with a readonly display for key-value pairs in graph mode.~~
- ~~Added a title attribute to provide a tooltip displaying the full key and value.~~
- Removed unnecessary editable attributes from elements.
- Make fields clickable to display text in a popover.
- Enable fields to be focusable, allowing them to be blurred to reset their state.