### PR TITLE
fix: show a key as title in table mode

### DIFF
--- a/src/lib/table/index.ts
+++ b/src/lib/table/index.ts
@@ -59,7 +59,7 @@ function genArrayDom(tree: Tree, node: Node) {
   const key2ExpanderId = genArrayExpanderIds(tree, node);
   const rowForHeaders = headers.length
     ? h("tr", indexHeader)
-        .addChildren(headers.map((key) => genTableHeader(tree, node, key, key2ExpanderId[key])))
+        .addChildren(headers.map((key) => genTableHeader(key, key2ExpanderId[key])))
         .class("sticky-scroll")
     : "";
 
@@ -89,29 +89,15 @@ function genObjectDom(tree: Tree, node: Node) {
     h("tbody").addChildren(
       // generate key:value pair as the row
       tree.mapChildren(node, (child, key) =>
-        h("tr", genTableHeader(tree, node, key, key2ExpanderId[key]), h("td", genDom(tree, child))),
+        h("tr", genTableHeader(key, key2ExpanderId[key]), h("td", genDom(tree, child))),
       ),
     ),
   ).class("tbl");
 }
 
-const nodeTypeToPrefixMap: Partial<Record<NodeType, string>> = {
-  object: "{}",
-  array: "[]",
-};
-
-function genTableHeader(tree: Tree, node: Node, key: string, expanderId?: string) {
-  const path = genKeyAndTypeList(tree, node.id, key);
-  const title = path
-    .map(({ nodeType, key }, i) => {
-      // last key in the path has no prefix
-      const prefix = i < path.length - 1 ? nodeTypeToPrefixMap[nodeType!] + " " : "";
-      return `${prefix}${key.replaceAll('"', "&quot;")}`;
-    })
-    .join("\n");
+function genTableHeader(key: string, expanderId?: string) {
   const keyDom = h("span", key || '""').class(key ? "text-hl-key" : "text-hl-empty");
-
-  return h("th", h("div", keyDom, genExpander(expanderId)).class("tbl-key")).title(title);
+  return h("th", h("div", keyDom, genExpander(expanderId)).class("tbl-key")).title(key);
 }
 
 function genExpander(expanderId?: string) {


### PR DESCRIPTION
This fixes to show the right title by displaying its key value.

**Changes:**
- Fixed an issue where a concatenated list of keys was being displayed as a tooltip for a key value in table mode.
- The title attribute is now correctly applied to show the key as a tooltip when hovering over the corresponding key value.

**Additional changes:**

- Removed unused types and parameters from the function.

**Screenshot:**
![Screenshot 2024-10-20 at 7 16 14 PM (2)](https://github.com/user-attachments/assets/60747091-1f04-4fa4-a9ed-7653408ff2d4)
