### PR TITLE
enh: show title in table mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -280,7 +280,8 @@ body {
       display: inline-block;
       max-width: var(--max-key-length);
       white-space: nowrap;
-      overflow-x: auto;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
     }
 
     :not(:first-child) {
@@ -314,7 +315,8 @@ body {
     display: inline-block;
     max-width: var(--max-value-length);
     white-space: nowrap;
-    overflow-x: auto;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
   }
 }
 

--- a/src/lib/table/index.ts
+++ b/src/lib/table/index.ts
@@ -36,6 +36,7 @@ function genDom(tree: Tree, node: Node, addExpander?: boolean): H {
   if (node.type === "string") {
     return h("span", node.value || '""')
       .class("tbl-val", node.value ? "text-hl-string" : "text-hl-empty")
+      .title(node.value)
       .id(id);
   } else {
     return h("span", getRawValue(node)!).class("tbl-val", `text-hl-${node.type}`).id(id);


### PR DESCRIPTION
This update hides the scrollbar for overflowing text and uses a tooltip to display the full content in table mode.

**Changes:**
- Removed the visible scrollbar for overflowing text in table mode.
- Added the title attribute to display the full key and value as a tooltip when hovering over truncated text.
