### PR TITLE
fix: escape&unescape asymmetry and refactored implementation

### DIFF
--- a/src/lib/worker/command/escape.ts
+++ b/src/lib/worker/command/escape.ts
@@ -1,26 +1,28 @@
-export function escape(text: string) {
-  return (
-    text
-      .replace(/[\\]/g, "\\\\")
-      .replace(/[\"]/g, '\\"')
-      .replace(/[\/]/g, "\\/")
-      .replace(/[\b]/g, "\\b")
-      .replace(/[\f]/g, "\\f")
-      // FIXME: 换行符会被转义成 \n
-      .replace(/[\n]/g, "\\n")
-      .replace(/[\r]/g, "\\r")
-      .replace(/[\t]/g, "\\t")
-  );
+const ESCAPE_MAP: Record<string, string> = {
+  '\\': '\\\\', '"': '\\"', '/': '\\/',
+  '\b': '\\b', '\f': '\\f', '\n': '\\n',
+  '\r': '\\r', '\t': '\\t',
+};
+
+const UNESCAPE_MAP: Record<string, string> = {
+  b: '\b', f: '\f', n: '\n',
+  r: '\r', t: '\t', '"': '"',
+  '\\': '\\', '/': '/',
+};
+
+const ESCAPE_RE = /[\\"\u0000-\u001F\/]/g;
+const UNESCAPE_RE = /(\\+)(.)/g;
+
+export function escape(text: string): string {
+  return text.replace(ESCAPE_RE, ch => ESCAPE_MAP[ch] || ch);
 }
 
-export function unescape(text: string) {
-  return text
-    .replace(/[\\]n/g, "\n")
-    .replace(/[\\]'/g, "'")
-    .replace(/[\\]"/g, '"')
-    .replace(/[\\]&/g, "&")
-    .replace(/[\\]r/g, "\r")
-    .replace(/[\\]t/g, "\t")
-    .replace(/[\\]b/g, "\b")
-    .replace(/[\\]f/g, "\f");
+export function unescape(text: string): string {
+  return text.replace(UNESCAPE_RE, (_m, bs, c) => {
+    const cnt = bs.length, half = cnt >> 1;
+    const prefix = '\\'.repeat(half);
+    return cnt % 2 === 1 && UNESCAPE_MAP[c] !== undefined
+        ? prefix + UNESCAPE_MAP[c]
+        : prefix + (cnt % 2 ? '\\' : '') + c;
+  });
 }


### PR DESCRIPTION
## Reason
The original `escape` function included a FIXME note regarding incomplete handling of line break escapes. Additionally, the `unescape` function had several issues:
- It could not correctly interpret multiple consecutive backslashes, leading to asymmetric restoration.
- Multiple chained `.replace` calls lacked contextual awareness, causing incorrect processing of valid literal backslashes (`\`).

## Changes
- Introduced centralized character handling using `ESC_MAP` and `UNESC_MAP` mapping tables.
- The `escape` function now uses a unified regular expression to replace control characters and special symbols consistently.
- The `unescape` function employs the pattern `/(\\+)(.)/g` to match sequences of backslashes, using the parity of their count to decide whether to interpret the escape or treat it as a literal.
- This approach guarantees symmetrical restoration of all escaped sequences, including complex cases like `\\\"` and `\\\\n`.

## Advantages
- Simplified structure: unified mappings, regular expression matching, and a single-pass traversal.
- Symmetrical behavior: applying `escape` followed by `unescape` preserves the original characters exactly.
- Easy extensibility: adding new escape characters only requires updating the mapping tables.
- Fully resolves the FIXME issue in the original `escape` implementation.

## Test
Testing revealed that when pasting content, attribute keys are auto-formatted, preventing escaped sequences in keys. However, modifying the input directly—whether in keys or values—allows `escape` and `unescape` to function correctly and symmetrically.

![](https://upyun.thatcdn.cn/myself/typora/20250608050559.png)