### PR TITLE
fix: improve footer links for small screens and make year dynamic

### DIFF
--- a/src/containers/landing/Footer.tsx
+++ b/src/containers/landing/Footer.tsx
@@ -24,15 +24,17 @@ export default function Footer() {
   ];
 
   return (
-    <footer className="flex h-12 items-center justify-center w-full border-t">
-      <div className="flex items-center w-full max-w-page-header md:px-8 px-4 gap-x-8 text-xs text-slate-500">
-        <div className="flex items-center gap-2">
+    <footer className="flex sm:h-12 min-h-12 py-4 sm:py-0 items-center justify-center w-full border-t">
+      <div className="flex flex-col sm:flex-row items-center w-full max-w-page-header sm:px-8 px-4 gap-y-3 sm:gap-x-8 text-xs text-slate-500">
+        <div className="flex items-center gap-2 shrink-0">
           <Logo className="w-[20px] h-[20px] text-slate-500" />
-          <span>{"© 2025 JSON For You"}</span>
+          <span className="whitespace-nowrap">{"© 2025 JSON For You"}</span>
         </div>
-        <Legal />
+        <div className="flex items-center gap-4 sm:gap-8 sm:ml-0">
+          <Legal />
+        </div>
         {isCN && <Upyun />}
-        <div className="ml-auto lg:flex hidden gap-8">
+        <div className="flex flex-wrap justify-center items-center gap-4 sm:gap-8 sm:ml-auto">
           {items.map((item, i) => (
             <FooterLink key={i} title={item.title} href={item.href} />
           ))}

--- a/src/containers/landing/Footer.tsx
+++ b/src/containers/landing/Footer.tsx
@@ -28,7 +28,7 @@ export default function Footer() {
       <div className="flex flex-col sm:flex-row items-center w-full max-w-page-header sm:px-8 px-4 gap-y-3 sm:gap-x-8 text-xs text-slate-500">
         <div className="flex items-center gap-2 shrink-0">
           <Logo className="w-[20px] h-[20px] text-slate-500" />
-          <span className="whitespace-nowrap">{"© 2025 JSON For You"}</span>
+          <span className="whitespace-nowrap">{`© ${new Date().getFullYear()} JSON For You`}</span>
         </div>
         <div className="flex items-center gap-4 sm:gap-8 sm:ml-0">
           <Legal />


### PR DESCRIPTION
## Problem
All of the footer links were not showing up on smaller screens, and the copyright year was hardcoded to 2025.

## What Changed
- Updated the footer layout to adjust cleanly from vertical to horizontal spacing (`flex-col sm:flex-row`).
- Improved spacing and text wrapping so all links fit perfectly on smaller displays.
- Made the copyright year dynamic so it updates automatically.

## Screenshots

| Before | After |
|---|---|
|<img width="534" height="78" alt="image" src="https://github.com/user-attachments/assets/207e8ac1-0da4-46f5-98d6-977634403353" />|<img width="537" height="179" alt="image" src="https://github.com/user-attachments/assets/8bb1eb35-b10b-4ebf-b328-b290baa62bca" />|
|<img width="954" height="84" alt="image" src="https://github.com/user-attachments/assets/f76eaa0c-d678-4416-9583-0c29ba717f34" />|<img width="959" height="92" alt="image" src="https://github.com/user-attachments/assets/f8678337-34d2-42c1-aba4-df676c342bed" />|

### Before
https://github.com/user-attachments/assets/755034a8-869b-435f-8ac1-9db864650e17

### After
https://github.com/user-attachments/assets/6a0b9164-0178-4563-964c-8b59e0413a9e













